### PR TITLE
Fix: remove hardcoded JWT fallback secret

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,6 @@
                 "@types/cors": "^2.8.17",
                 "@types/express": "^4.17.25",
                 "@types/jsonwebtoken": "^9.0.10",
-                "@types/node": "^20.19.32",
                 "bcryptjs": "^3.0.3",
                 "cors": "^2.8.5",
                 "dotenv": "^16.6.1",
@@ -28,6 +27,7 @@
                 "typescript": "^5.4.5"
             },
             "devDependencies": {
+                "@types/node": "^25.9.2",
                 "nodemon": "^3.1.0"
             }
         },
@@ -309,12 +309,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.19.32",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.32.tgz",
-            "integrity": "sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==",
+            "version": "25.9.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+            "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.21.0"
+                "undici-types": ">=7.24.0 <7.24.7"
             }
         },
         "node_modules/@types/qs": {
@@ -2776,9 +2776,9 @@
             "license": "MIT"
         },
         "node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "version": "7.24.6",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
             "license": "MIT"
         },
         "node_modules/unpipe": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,6 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.25",
         "@types/jsonwebtoken": "^9.0.10",
-        "@types/node": "^20.19.32",
         "bcryptjs": "^3.0.3",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
@@ -32,6 +31,7 @@
         "typescript": "^5.4.5"
     },
     "devDependencies": {
+        "@types/node": "^25.9.2",
         "nodemon": "^3.1.0"
     }
 }

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -8,9 +8,7 @@ const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
 // Generate JWT
 const generateToken = (id: string) => {
-    return jwt.sign({ id }, process.env.JWT_SECRET || 'fallback_secret', {
-        expiresIn: '30d'
-    });
+    jwt.sign({ id }, process.env.JWT_SECRET!, { expiresIn: '30d' });
 };
 
 // @desc    Register new user

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -8,7 +8,7 @@ const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 
 // Generate JWT
 const generateToken = (id: string) => {
-    jwt.sign({ id }, process.env.JWT_SECRET!, { expiresIn: '30d' });
+    return jwt.sign({ id }, process.env.JWT_SECRET!, { expiresIn: '30d' });
 };
 
 // @desc    Register new user

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -24,7 +24,7 @@ const protect = async (req: Request, res: Response, next: NextFunction) => {
         try {
             token = req.headers.authorization.split(' ')[1];
 
-            const decoded = jwt.verify(token, process.env.JWT_SECRET || 'fallback_secret') as JwtPayload;
+            const decoded = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload;
 
             const user = await prisma.user.findUnique({
                 where: { id: decoded.id },

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -65,6 +65,12 @@ app.get('/api/health', (req: Request, res: Response) => {
     res.json({ status: 'ok', message: 'Server is healthy' });
 });
 
+// server.ts — add before app.listen()
+if (!process.env.JWT_SECRET) {
+  throw new Error('FATAL: JWT_SECRET environment variable is not set.');
+}
+
+
 app.listen(port, () => {
     console.log(`[server]: Server is running at http://localhost:${port}`);
 });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,6 +5,11 @@ import connectDB from './config/db';
 
 dotenv.config();
 
+// server.ts — add before app.listen()
+if (!process.env.JWT_SECRET) {
+  throw new Error('FATAL: JWT_SECRET environment variable is not set.');
+}
+
 const app: Express = express();
 const port = process.env.PORT || 5000;
 
@@ -64,12 +69,6 @@ app.get('/', (req: Request, res: Response) => {
 app.get('/api/health', (req: Request, res: Response) => {
     res.json({ status: 'ok', message: 'Server is healthy' });
 });
-
-// server.ts — add before app.listen()
-if (!process.env.JWT_SECRET) {
-  throw new Error('FATAL: JWT_SECRET environment variable is not set.');
-}
-
 
 app.listen(port, () => {
     console.log(`[server]: Server is running at http://localhost:${port}`);

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "types": ["node"],
         "target": "es2020",
         "module": "Node16",
         "outDir": "./dist",


### PR DESCRIPTION
### Summary

Resolves the security issue where `JWT_SECRET` missing from the environment caused the app to silently fall back to a hardcoded string (`'fallback_secret'`) in both `authController.ts` and `authMiddleware.ts`. An attacker knowing this string could forge valid JWTs and authenticate as any user, including admins, with no warning logged.

---

### Changes

- **server.ts** — added a startup guard that throws a fatal error if `JWT_SECRET` is not set, preventing the server from starting in a misconfigured state
- **authController.ts** — replaced `process.env.JWT_SECRET || 'fallback_secret'` with `process.env.JWT_SECRET!` in `generateToken`
- **authMiddleware.ts** — same replacement in `jwt.verify()` inside the `protect` middleware

---

### Code diff (key changes)

```diff
// server.ts — startup guard (added before app.listen())
- // no check
+ if (!process.env.JWT_SECRET) {
+   throw new Error('FATAL: JWT_SECRET environment variable is not set.');
+ }

// authController.ts
- jwt.sign({ id }, process.env.JWT_SECRET || 'fallback_secret', { expiresIn: '30d' });
+ jwt.sign({ id }, process.env.JWT_SECRET!, { expiresIn: '30d' });

// authMiddleware.ts
- jwt.verify(token, process.env.JWT_SECRET || 'fallback_secret') as JwtPayload;
+ jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload;
```

---

### Why this approach

The startup guard in `server.ts` is the single enforcement point — it ensures that by the time any request reaches the middleware or controller, `JWT_SECRET` is guaranteed to be set. The `!` non-null assertion in the other two files reflects that guarantee at the type level, removing the need for a runtime fallback.

---

### Testing

- Start the backend **without** `JWT_SECRET` set — server should exit immediately with the fatal error message
- Start with `JWT_SECRET` set — server starts normally, login and protected routes work as before
- Attempt to use a JWT signed with `'fallback_secret'` — request is rejected with 401

---

### Related

Closes #3 — [Security] JWT signed with hardcoded fallback secret when JWT_SECRET env var is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Development-only packages reorganized so they are excluded from production builds.
  * TypeScript config updated to explicitly include Node.js type definitions for improved type checking.
* **Bug Fixes / Reliability**
  * App now enforces a configured authentication secret at startup and uses it exclusively for token handling, preventing the server from running without proper auth configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->