### PR TITLE
Fix #16: Replace native confirm() with accessible Radix AlertDialog for note deletion

### DIFF
--- a/app/src/sections/Notes.tsx
+++ b/app/src/sections/Notes.tsx
@@ -15,6 +15,16 @@ import { Input } from '@/components/ui/input';
 import { toast } from 'sonner';
 import { getUserProgress, updateNotes } from '@/api/userActions';
 import { getAllProblems } from '@/api/content';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
 
 interface Note {
   id: string;           // UserProgress _id
@@ -37,6 +47,7 @@ export function Notes() {
   // New note creation state
   const [newNoteProblemId, setNewNoteProblemId] = useState('');
   const [problemSearch, setProblemSearch] = useState('');
+  const [noteToDelete, setNoteToDelete] = useState<Note | null>(null);
 
   // Fetch notes from backend
   useEffect(() => {
@@ -154,19 +165,24 @@ export function Notes() {
     setSelectedNote(null);
   };
 
-  const handleDelete = async (note: Note) => {
-    if (confirm('Are you sure you want to delete this note?')) {
-      try {
-        // Delete note by setting it to empty string
-        await updateNotes(note.problemId, '');
-        setNotes(notes.filter(n => n.id !== note.id));
-        if (selectedNote?.id === note.id) {
-          setSelectedNote(null);
-        }
-        toast.success('Note deleted');
-      } catch (e) {
-        toast.error('Failed to delete note');
+  const handleDelete = (note: Note) => {
+    setNoteToDelete(note);
+  };
+
+  const confirmDelete = async () => {
+    if (!noteToDelete) return;
+    try {
+      // Delete note by setting it to empty string
+      await updateNotes(noteToDelete.problemId, '');
+      setNotes(notes.filter(n => n.id !== noteToDelete.id));
+      if (selectedNote?.id === noteToDelete.id) {
+        setSelectedNote(null);
       }
+      toast.success('Note deleted');
+    } catch (e) {
+      toast.error('Failed to delete note');
+    } finally {
+      setNoteToDelete(null);
     }
   };
 
@@ -423,6 +439,30 @@ export function Notes() {
           </motion.div>
         </div>
       </div>
+
+      <AlertDialog open={!!noteToDelete} onOpenChange={(open) => !open && setNoteToDelete(null)}>
+        <AlertDialogContent className="bg-[#141414] border-white/10 text-white max-w-md">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-xl font-bold text-white">
+              Delete note for {noteToDelete?.problemTitle}?
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-white/60 text-sm">
+              This action cannot be undone. Are you sure you want to permanently delete this note?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="mt-4">
+            <AlertDialogCancel className="bg-white/5 border-white/10 text-white hover:bg-white/10 hover:text-white transition-colors">
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={confirmDelete}
+              className="bg-red-600 text-white hover:bg-red-700 transition-colors"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }

--- a/app/src/sections/Notes.tsx
+++ b/app/src/sections/Notes.tsx
@@ -180,6 +180,7 @@ export function Notes() {
       }
       toast.success('Note deleted');
     } catch (e) {
+      console.error('Failed to delete note', e);
       toast.error('Failed to delete note');
     } finally {
       setNoteToDelete(null);


### PR DESCRIPTION
Closes #16

## Description

This PR replaces the native browser `confirm()` dialog used for note deletion with a styled and accessible Radix UI `AlertDialog`.

## Changes Made

* Replaced the native `confirm()` dialog in `Notes.tsx` with a Radix UI `AlertDialog`
* Added a confirmation modal displaying the associated problem title
* Added a permanent deletion warning message
* Styled the dialog to match the application's dark theme (`bg-[#141414]`, `border-white/10`)
* Added a red destructive action button for note deletion
* Added a cancel action that closes the dialog without making any changes
* Connected the dialog's delete action to the existing note deletion logic
* Removed dependency on the browser's native confirmation dialog

## Expected Behavior

When a user clicks the delete button:

1. A confirmation dialog opens
2. The dialog displays the problem title associated with the note
3. The user is warned that the action cannot be undone
4. Clicking **Delete** permanently removes the note
5. Clicking **Cancel** closes the dialog without deleting the note

## Screenshot

### After
<img width="957" height="437" alt="resolved" src="https://github.com/user-attachments/assets/3638db96-4bd3-4155-8d05-0b212e0672b6" />


## Acceptance Criteria

* [x] No native `confirm()` dialog is used for note deletion
* [x] Accessible Radix UI `AlertDialog` is used
* [x] Problem title is displayed in the confirmation dialog
* [x] Destructive action is visually distinguished with a red button
* [x] Cancel action closes the dialog without side effects
* [x] Dialog follows the application's dark theme styling
* [x] Keyboard focus is managed by Radix AlertDialog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced note deletion with a modal confirmation dialog, replacing the standard browser popup.
  * Added toast notifications for deletion feedback, improving clarity on operation success or failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->