### PR TITLE
feat: add vitest unit tests for authController and userActionController (Closes #23)

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,9 @@
         "start": "node dist/server.js",
         "dev": "nodemon src/server.ts",
         "build": "prisma generate && tsc",
-        "seed": "ts-node src/scripts/seed.ts"
+        "seed": "ts-node src/scripts/seed.ts",
+        "test": "vitest run",
+        "test:coverage": "vitest run --coverage"
     },
     "keywords": [],
     "author": "Rishabh",
@@ -33,6 +35,9 @@
     },
     "devDependencies": {
         "@types/node": "^25.9.2",
-        "nodemon": "^3.1.0"
+        "@vitest/coverage-v8": "^4.1.8",
+        "nodemon": "^3.1.0",
+        "vitest": "^4.1.8",
+        "vitest-mock-extended": "^4.0.0"
     }
 }

--- a/backend/tests/__mocks__/prisma.ts
+++ b/backend/tests/__mocks__/prisma.ts
@@ -1,0 +1,2 @@
+// empty - not needed anymore
+export {};

--- a/backend/tests/authController.test.ts
+++ b/backend/tests/authController.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import bcrypt from 'bcryptjs';
 
+
+
+const verifyIdTokenMock = vi.hoisted(() => vi.fn());
+
+vi.mock('google-auth-library', () => {
+    return {
+        OAuth2Client: function(this: any) {
+            this.verifyIdToken = verifyIdTokenMock;
+        }
+    };
+});
+
 vi.mock('../src/config/db', () => ({
     prisma: {
         user: {
@@ -11,13 +23,12 @@ vi.mock('../src/config/db', () => ({
     }
 }));
 
-import { registerUser, loginUser } from '../src/controllers/authController';
+import { registerUser, loginUser, googleAuth } from '../src/controllers/authController';
 import { prisma } from '../src/config/db';
 
 beforeEach(() => {
     vi.clearAllMocks();
 });
-import { googleAuth } from '../src/controllers/authController';
 // Helper to make mock req/res
 const mockRes = () => {
     const res: any = {};
@@ -146,6 +157,7 @@ describe('loginUser', () => {
 
 describe('googleAuth', () => {
     it('returns 400 for invalid google token', async () => {
+        verifyIdTokenMock.mockRejectedValueOnce(new Error('invalid token'));
         const req = mockReq({ token: 'bad-token' });
         const res = mockRes();
 

--- a/backend/tests/authController.test.ts
+++ b/backend/tests/authController.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import bcrypt from 'bcryptjs';
+
+vi.mock('../src/config/db', () => ({
+    prisma: {
+        user: {
+            findUnique: vi.fn(),
+            create: vi.fn(),
+            update: vi.fn(),
+        }
+    }
+}));
+
+import { registerUser, loginUser } from '../src/controllers/authController';
+import { prisma } from '../src/config/db';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+import { googleAuth } from '../src/controllers/authController';
+// Helper to make mock req/res
+const mockRes = () => {
+    const res: any = {};
+    res.status = vi.fn().mockReturnValue(res);
+    res.json = vi.fn().mockReturnValue(res);
+    return res;
+};
+
+const mockReq = (body: object) => ({ body } as any);
+
+// ── registerUser ──────────────────────────────────────────────
+
+describe('registerUser', () => {
+    it('returns 400 if fields are missing', async () => {
+        const req = mockReq({ name: '', email: '', password: '' });
+        const res = mockRes();
+
+        await registerUser(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ message: 'Please add all fields' });
+    });
+
+    it('returns 400 if user already exists', async () => {
+        (prisma.user.findUnique as any).mockResolvedValue({ id: '1', email: 'test@test.com' });
+
+        const req = mockReq({ name: 'Aditi', email: 'test@test.com', password: 'pass123' });
+        const res = mockRes();
+
+        await registerUser(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ message: 'User already exists' });
+    });
+
+    it('creates user and returns 201 with token', async () => {
+        (prisma.user.findUnique as any).mockResolvedValue(null);
+        (prisma.user.create as any).mockResolvedValue({
+            id: 'abc123',
+            name: 'Aditi',
+            email: 'aditi@test.com',
+            role: 'USER',
+            xp_points: 0,
+            streak_days: 0,
+            solvedProblems: [],
+            bookmarks: [],
+            activityLog: []
+        });
+
+        const req = mockReq({ name: 'Aditi', email: 'aditi@test.com', password: 'pass123' });
+        const res = mockRes();
+
+        await registerUser(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(201);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            _id: 'abc123',
+            email: 'aditi@test.com',
+            token: expect.any(String)
+        }));
+    });
+});
+
+// ── loginUser ─────────────────────────────────────────────────
+
+describe('loginUser', () => {
+    it('returns 400 for invalid credentials', async () => {
+        (prisma.user.findUnique as any).mockResolvedValue(null);
+
+        const req = mockReq({ email: 'wrong@test.com', password: 'wrongpass' });
+        const res = mockRes();
+
+        await loginUser(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ message: 'Invalid credentials' });
+    });
+
+    it('returns 403 if user is banned', async () => {
+        const hashed = await bcrypt.hash('pass123', 10);
+        (prisma.user.findUnique as any).mockResolvedValue({
+            id: '1',
+            email: 'banned@test.com',
+            password: hashed,
+            isBanned: true
+        });
+
+        const req = mockReq({ email: 'banned@test.com', password: 'pass123' });
+        const res = mockRes();
+
+        await loginUser(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(403);
+        expect(res.json).toHaveBeenCalledWith({ message: 'Your account has been suspended' });
+    });
+
+    it('returns user + token for valid credentials', async () => {
+        const hashed = await bcrypt.hash('pass123', 10);
+        (prisma.user.findUnique as any).mockResolvedValue({
+            id: 'abc123',
+            name: 'Aditi',
+            email: 'aditi@test.com',
+            password: hashed,
+            isBanned: false,
+            role: 'USER',
+            xp_points: 100,
+            streak_days: 3,
+            solvedProblems: [],
+            bookmarks: [],
+            activityLog: []
+        });
+
+        const req = mockReq({ email: 'aditi@test.com', password: 'pass123' });
+        const res = mockRes();
+
+        await loginUser(req, res);
+
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+            _id: 'abc123',
+            token: expect.any(String)
+        }));
+    });
+});
+// ── googleAuth ────────────────────────────────────────────────
+
+
+describe('googleAuth', () => {
+    it('returns 400 for invalid google token', async () => {
+        const req = mockReq({ token: 'bad-token' });
+        const res = mockRes();
+
+        await googleAuth(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ message: 'Google Auth Failed' });
+    });
+});

--- a/backend/tests/userActionController.test.ts
+++ b/backend/tests/userActionController.test.ts
@@ -1,0 +1,312 @@
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/config/db', () => ({
+    prisma: {
+        userProgress: {
+            findUnique: vi.fn(),
+            create: vi.fn(),
+            update: vi.fn(),
+            findMany: vi.fn(),
+        },
+        user: {
+            findUnique: vi.fn(),
+            update: vi.fn(),
+        }
+    }
+}));
+
+import { updateProblemStatus } from '../src/controllers/userActionController';
+import { prisma } from '../src/config/db';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+import { toggleBookmark, updateNotes, getUserProgress } from '../src/controllers/userActionController';
+
+const mockRes = () => {
+    const res: any = {};
+    res.status = vi.fn().mockReturnValue(res);
+    res.json = vi.fn().mockReturnValue(res);
+    return res;
+};
+
+const mockReq = (params: object, body: object, userId = '507f1f77bcf86cd799439011') => ({
+    params,
+    body,
+    user: { id: userId }
+} as any);
+
+const baseUser = {
+    id: '507f1f77bcf86cd799439011',
+    xp_points: 100,
+    streak_days: 3,
+    last_active: null,
+    solvedProblems: [],
+    bookmarks: [],
+    activityLog: []
+};
+
+// ── Streak tests ──────────────────────────────────────────────
+
+describe('streak logic in updateProblemStatus', () => {
+    it('increments streak when last active was yesterday', async () => {
+        const yesterday = new Date();
+        yesterday.setDate(yesterday.getDate() - 1);
+
+        (prisma.userProgress.findUnique as any).mockResolvedValue(null);
+        (prisma.userProgress.create as any).mockResolvedValue({ id: 'p1', status: 'SOLVED' });
+        (prisma.user.findUnique as any).mockResolvedValue({
+            ...baseUser,
+            last_active: yesterday,
+            streak_days: 3
+        });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob1' }, { status: 'SOLVED' });
+        const res = mockRes();
+
+        await updateProblemStatus(req, res);
+
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ streak_days: 4 })
+        }));
+    });
+
+    it('resets streak to 1 when last active was 2+ days ago', async () => {
+        const twoDaysAgo = new Date();
+        twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+
+        (prisma.userProgress.findUnique as any).mockResolvedValue(null);
+        (prisma.userProgress.create as any).mockResolvedValue({ id: 'p1', status: 'SOLVED' });
+        (prisma.user.findUnique as any).mockResolvedValue({
+            ...baseUser,
+            last_active: twoDaysAgo,
+            streak_days: 5
+        });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob1' }, { status: 'SOLVED' });
+        const res = mockRes();
+
+        await updateProblemStatus(req, res);
+
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ streak_days: 1 })
+        }));
+    });
+
+    it('keeps streak unchanged when already active today', async () => {
+        const today = new Date();
+
+        (prisma.userProgress.findUnique as any).mockResolvedValue(null);
+        (prisma.userProgress.create as any).mockResolvedValue({ id: 'p1', status: 'SOLVED' });
+        (prisma.user.findUnique as any).mockResolvedValue({
+            ...baseUser,
+            last_active: today,
+            streak_days: 7
+        });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob1' }, { status: 'SOLVED' });
+        const res = mockRes();
+
+        await updateProblemStatus(req, res);
+
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ streak_days: 7 })
+        }));
+    });
+});
+
+// ── XP tests ──────────────────────────────────────────────────
+
+describe('XP logic in updateProblemStatus', () => {
+    it('increments XP by 25 when problem newly solved', async () => {
+        (prisma.userProgress.findUnique as any).mockResolvedValue(null);
+        (prisma.userProgress.create as any).mockResolvedValue({ id: 'p1', status: 'SOLVED' });
+        (prisma.user.findUnique as any).mockResolvedValue({ ...baseUser, last_active: null });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob1' }, { status: 'SOLVED' });
+        const res = mockRes();
+
+        await updateProblemStatus(req, res);
+
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ xp_points: { increment: 25 } })
+        }));
+    });
+
+    it('decrements XP by 25 when problem un-solved', async () => {
+        (prisma.userProgress.findUnique as any).mockResolvedValue({ id: 'p1', status: 'SOLVED' });
+        (prisma.userProgress.update as any).mockResolvedValue({ id: 'p1', status: 'TODO' });
+        (prisma.user.findUnique as any).mockResolvedValue({
+            ...baseUser,
+            solvedProblems: [{ problemId: 'prob1', solvedAt: new Date() }]
+        });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob1' }, { status: 'TODO' });
+        const res = mockRes();
+
+        await updateProblemStatus(req, res);
+
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ xp_points: { decrement: 25 } })
+        }));
+    });
+
+    it('does not change XP when status changes between non-SOLVED states', async () => {
+        (prisma.userProgress.findUnique as any).mockResolvedValue({ id: 'p1', status: 'TODO' });
+        (prisma.userProgress.update as any).mockResolvedValue({ id: 'p1', status: 'IN_PROGRESS' });
+
+        const req = mockReq({ problemId: 'prob1' }, { status: 'IN_PROGRESS' });
+        const res = mockRes();
+
+        await updateProblemStatus(req, res);
+
+        // user.update should NOT be called for XP changes
+        expect(prisma.user.update).not.toHaveBeenCalled();
+    });
+});
+
+// ── Activity log tests ────────────────────────────────────────
+
+describe('activity log in updateProblemStatus', () => {
+    it('adds new date entry to activity log when first solve of the day', async () => {
+        const todayStr = new Date().toISOString().split('T')[0];
+
+        (prisma.userProgress.findUnique as any).mockResolvedValue(null);
+        (prisma.userProgress.create as any).mockResolvedValue({ id: 'p1', status: 'SOLVED' });
+        (prisma.user.findUnique as any).mockResolvedValue({
+            ...baseUser,
+            activityLog: [],
+            last_active: null
+        });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob1' }, { status: 'SOLVED' });
+        const res = mockRes();
+
+        await updateProblemStatus(req, res);
+
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({
+                activityLog: [{ date: todayStr, count: 1 }]
+            })
+        }));
+    });
+
+    it('increments count on existing date entry', async () => {
+        const todayStr = new Date().toISOString().split('T')[0];
+
+        (prisma.userProgress.findUnique as any).mockResolvedValue(null);
+        (prisma.userProgress.create as any).mockResolvedValue({ id: 'p1', status: 'SOLVED' });
+        (prisma.user.findUnique as any).mockResolvedValue({
+            ...baseUser,
+            activityLog: [{ date: todayStr, count: 2 }],
+            last_active: new Date()
+        });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob2' }, { status: 'SOLVED' });
+        const res = mockRes();
+
+        await updateProblemStatus(req, res);
+
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({
+                activityLog: [{ date: todayStr, count: 3 }]
+            })
+        }));
+    });
+});
+
+// ── toggleBookmark ────────────────────────────────────────────
+
+describe('toggleBookmark', () => {
+    it('creates progress and adds bookmark when none exists', async () => {
+        (prisma.userProgress.findUnique as any).mockResolvedValue(null);
+        (prisma.userProgress.create as any).mockResolvedValue({ id: 'p1', is_bookmarked: true });
+        (prisma.user.findUnique as any).mockResolvedValue({ ...baseUser, bookmarks: [] });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob1' }, {});
+        const res = mockRes();
+
+        await toggleBookmark(req, res);
+
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ bookmarks: ['prob1'] })
+        }));
+        expect(res.json).toHaveBeenCalled();
+    });
+
+    it('toggles off bookmark when already bookmarked', async () => {
+        (prisma.userProgress.findUnique as any).mockResolvedValue({ id: 'p1', is_bookmarked: true });
+        (prisma.userProgress.update as any).mockResolvedValue({ id: 'p1', is_bookmarked: false });
+        (prisma.user.findUnique as any).mockResolvedValue({ ...baseUser, bookmarks: ['prob1'] });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob1' }, {});
+        const res = mockRes();
+
+        await toggleBookmark(req, res);
+
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ bookmarks: [] })
+        }));
+    });
+});
+
+// ── updateNotes ───────────────────────────────────────────────
+
+describe('updateNotes', () => {
+    it('updates notes on existing progress', async () => {
+        (prisma.userProgress.findUnique as any).mockResolvedValue({ id: 'p1', notes: '' });
+        (prisma.userProgress.update as any).mockResolvedValue({ id: 'p1', notes: 'my note' });
+
+        const req = mockReq({ problemId: 'prob1' }, { notes: 'my note' });
+        const res = mockRes();
+
+        await updateNotes(req, res);
+
+        expect(prisma.userProgress.update).toHaveBeenCalled();
+        expect(res.json).toHaveBeenCalled();
+    });
+
+    it('creates progress with notes when none exists', async () => {
+        (prisma.userProgress.findUnique as any).mockResolvedValue(null);
+        (prisma.userProgress.create as any).mockResolvedValue({ id: 'p1', notes: 'new note' });
+
+        const req = mockReq({ problemId: 'prob1' }, { notes: 'new note' });
+        const res = mockRes();
+
+        await updateNotes(req, res);
+
+        expect(prisma.userProgress.create).toHaveBeenCalled();
+        expect(res.json).toHaveBeenCalled();
+    });
+});
+
+// ── getUserProgress ───────────────────────────────────────────
+
+describe('getUserProgress', () => {
+    it('returns all progress for user', async () => {
+        (prisma.userProgress.findMany as any).mockResolvedValue([
+            { id: 'p1', status: 'SOLVED' },
+            { id: 'p2', status: 'TODO' }
+        ]);
+
+        const req = mockReq({}, {});
+        const res = mockRes();
+
+        await getUserProgress(req, res);
+
+        expect(res.json).toHaveBeenCalledWith([
+            { id: 'p1', status: 'SOLVED' },
+            { id: 'p2', status: 'TODO' }
+        ]);
+    });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        env: {
+            JWT_SECRET: 'test-secret-key',
+        },
+        coverage: {
+            provider: 'v8',
+            reporter: ['text', 'html'],
+            include: [
+                'src/controllers/authController.ts',
+                'src/controllers/userActionController.ts',
+            ],
+        },
+    },
+});


### PR DESCRIPTION
Closes #23

## Changes
- Installed vitest, @vitest/coverage-v8 in backend
- Created vitest.config.ts with coverage config
- Wrote 20 unit tests across authController and userActionController
- Tests cover: register, login, banned user, streak increment/reset, XP increment/decrement, activity log, bookmark toggle, notes update
- No real database connections — all Prisma calls mocked with vi.fn()

## Coverage
- authController: 68.75% statements
- userActionController: 92.68% statements  
- Overall: 83.84% (requirement was ≥70%) ✅

## Test run
`npm run test` → 20 passed
`npm run test:coverage` → 83.84% coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for authentication and user-action flows (registration, login, Google auth, progress updates, bookmarks, notes, streaks, XP, activity logs, and retrieval). Test suites include thorough scenarios for success, validation, and edge cases.

* **Chores**
  * Integrated Vitest with coverage reporting and added test/npm scripts; included a test configuration and simplified test mock setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->