### PR TITLE
fix: standardize streak system on UTC and document timezone behavior

### DIFF
--- a/app/src/sections/Dashboard.tsx
+++ b/app/src/sections/Dashboard.tsx
@@ -288,6 +288,7 @@ export function Dashboard({ onNavigate }: DashboardProps) {
               <motion.div
                 whileHover={{ scale: 1.05 }}
                 className="flex items-center gap-2 px-4 py-2 rounded-full glass cursor-default"
+                title="Streak resets at midnight UTC"
               >
                 <Flame className={`w-5 h-5 ${stats.currentStreak > 0 ? 'text-[#ff8a63]' : 'text-white/30'}`} />
                 <span className="text-white font-medium">{animStreak} day streak</span>
@@ -351,7 +352,7 @@ export function Dashboard({ onNavigate }: DashboardProps) {
           {[
             { label: 'Problems Solved', value: animSolved, sub: `of ${stats.totalProblems}`, icon: CheckCircle2, color: '#a088ff', glow: 'rgba(160,136,255,0.15)' },
             { label: 'XP Points', value: animXP, sub: `Level ${level}`, icon: Zap, color: '#ffd700', glow: 'rgba(255,215,0,0.12)' },
-            { label: 'Day Streak', value: animStreak, sub: stats.currentStreak > 0 ? 'Keep it up!' : 'Solve to start!', icon: Flame, color: '#ff8a63', glow: 'rgba(255,138,99,0.12)' },
+            { label: 'Day Streak', value: animStreak, sub: 'Resets at midnight UTC', icon: Flame, color: '#ff8a63', glow: 'rgba(255,138,99,0.12)' },
             { label: 'Global Rank', value: `#${rankInfo.rank}`, sub: `Top ${rankInfo.topPercent}%`, icon: Trophy, color: '#88ff9f', glow: 'rgba(136,255,159,0.12)' },
           ].map((stat) => (
             <motion.div

--- a/backend/src/controllers/userActionController.ts
+++ b/backend/src/controllers/userActionController.ts
@@ -33,6 +33,17 @@ export const updateProblemStatus = async (req: Request | any, res: Response) => 
         if (status === 'SOLVED' && previousStatus !== 'SOLVED') {
             const userDoc = await prisma.user.findUnique({ where: { id: userId } });
             if (userDoc) {
+                // ─────────────────────────────────────────────
+                // UTC-based streak logic
+                // ─────────────────────────────────────────────
+                // All date comparisons use UTC via toISOString().split('T')[0].
+                // Streak rules (all dates are UTC calendar dates):
+                //   1. If last_active is today (UTC) → streak unchanged
+                //   2. If last_active is yesterday (UTC) → streak increments by 1
+                //   3. If last_active is 2+ days ago (UTC) → streak resets to 1
+                //   4. If no last_active (new user) → streak starts at 1
+                // Streak resets at midnight UTC regardless of user's local timezone.
+                // ─────────────────────────────────────────────
                 const today = new Date();
                 const todayStr = today.toISOString().split('T')[0];
                 const lastActiveStr = userDoc.last_active ? new Date(userDoc.last_active).toISOString().split('T')[0] : null;

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -68,6 +68,13 @@ export const getDashboardStats = async (req: Request | any, res: Response) => {
         const totalUsers = await prisma.user.count();
         const topPercent = totalUsers > 0 ? Math.round((rank / totalUsers) * 100) : 100;
 
+        // ─────────────────────────────────────────────
+        // UTC-based streak validation for dashboard display
+        // ─────────────────────────────────────────────
+        // Reset streak to 0 if last_active is not today or yesterday (UTC).
+        // This handles cases where the user missed a UTC day.
+        // All date comparisons use UTC via toISOString().split('T')[0].
+        // ─────────────────────────────────────────────
         let currentStreak = user.streak_days || 0;
         const today = new Date();
         const todayStr = today.toISOString().split('T')[0];

--- a/backend/tests/userActionController.test.ts
+++ b/backend/tests/userActionController.test.ts
@@ -117,6 +117,103 @@ describe('streak logic in updateProblemStatus', () => {
             data: expect.objectContaining({ streak_days: 7 })
         }));
     });
+
+    // ── UTC timezone edge-case tests ──────────────────────────────
+
+    it('starts streak at 1 for new user with no last_active', async () => {
+        (prisma.userProgress.findUnique as any).mockResolvedValue(null);
+        (prisma.userProgress.create as any).mockResolvedValue({ id: 'p1', status: 'SOLVED' });
+        (prisma.user.findUnique as any).mockResolvedValue({
+            ...baseUser,
+            last_active: null,
+            streak_days: 0
+        });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob1' }, { status: 'SOLVED' });
+        const res = mockRes();
+
+        await updateProblemStatus(req, res);
+
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ streak_days: 1 })
+        }));
+    });
+
+    it('uses UTC date for comparison (same UTC day despite different local hours)', async () => {
+        // Simulate: last_active was at 23:30 UTC today (same UTC day as now)
+        const now = new Date();
+        const todayStr = now.toISOString().split('T')[0];
+        const lastActiveAt2330UTC = new Date(`${todayStr}T23:30:00.000Z`);
+
+        (prisma.userProgress.findUnique as any).mockResolvedValue(null);
+        (prisma.userProgress.create as any).mockResolvedValue({ id: 'p1', status: 'SOLVED' });
+        (prisma.user.findUnique as any).mockResolvedValue({
+            ...baseUser,
+            last_active: lastActiveAt2330UTC,
+            streak_days: 5
+        });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob1' }, { status: 'SOLVED' });
+        const res = mockRes();
+
+        await updateProblemStatus(req, res);
+
+        // Same UTC day → streak unchanged
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ streak_days: 5 })
+        }));
+    });
+
+    it('increments streak when last active was previous UTC day', async () => {
+        // Simulate: last_active was 23:59 UTC yesterday
+        const now = new Date();
+        const yesterdayStr = new Date(now.getTime() - 86400000).toISOString().split('T')[0];
+        const lastActiveAt2359UTC = new Date(`${yesterdayStr}T23:59:00.000Z`);
+
+        (prisma.userProgress.findUnique as any).mockResolvedValue(null);
+        (prisma.userProgress.create as any).mockResolvedValue({ id: 'p1', status: 'SOLVED' });
+        (prisma.user.findUnique as any).mockResolvedValue({
+            ...baseUser,
+            last_active: lastActiveAt2359UTC,
+            streak_days: 10
+        });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob1' }, { status: 'SOLVED' });
+        const res = mockRes();
+
+        await updateProblemStatus(req, res);
+
+        // Previous UTC day → streak increments
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ streak_days: 11 })
+        }));
+    });
+
+    it('resets streak when last active was 3 days ago (UTC)', async () => {
+        const threeDaysAgo = new Date();
+        threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+
+        (prisma.userProgress.findUnique as any).mockResolvedValue(null);
+        (prisma.userProgress.create as any).mockResolvedValue({ id: 'p1', status: 'SOLVED' });
+        (prisma.user.findUnique as any).mockResolvedValue({
+            ...baseUser,
+            last_active: threeDaysAgo,
+            streak_days: 15
+        });
+        (prisma.user.update as any).mockResolvedValue({});
+
+        const req = mockReq({ problemId: 'prob1' }, { status: 'SOLVED' });
+        const res = mockRes();
+
+        await updateProblemStatus(req, res);
+
+        expect(prisma.user.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({ streak_days: 1 })
+        }));
+    });
 });
 
 // ── XP tests ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Standardized streak system on UTC with clear documentation
- Added UTC timezone assumption comments to all streak logic
- Added "Resets at midnight UTC" note to Dashboard streak card
- Added 4 new unit tests for UTC timezone edge cases

## Changes
- `backend/src/controllers/userActionController.ts`: Added detailed UTC streak rules documentation
- `backend/src/controllers/userController.ts`: Added UTC streak validation comments
- `app/src/sections/Dashboard.tsx`: Changed streak card sub-label to "Resets at midnight UTC" and added tooltip to header badge
- `backend/tests/userActionController.test.ts`: Added 4 new tests for UTC edge cases

## UTC Streak Rules (documented in code)
1. If `last_active` is today (UTC) → streak unchanged
2. If `last_active` is yesterday (UTC) → streak increments by 1
3. If `last_active` is 2+ days ago (UTC) → streak resets to 1
4. If no `last_active` (new user) → streak starts at 1

## New Tests
- `starts streak at 1 for new user with no last_active`
- `uses UTC date for comparison (same UTC day despite different local hours)`
- `increments streak when last active was previous UTC day`
- `resets streak when last active was 3 days ago (UTC)`

## Closes
closes #6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Day Streak stat now includes a tooltip indicating when the streak resets
  * Updated Day Streak subtitle to clearly display "Resets at midnight UTC"

* **Tests**
  * Added comprehensive edge-case tests for streak calculation with UTC date boundaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->