### PR TITLE
ci: add GitHub Actions CI pipeline for TypeScript and ESLint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lint-and-typecheck:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      # ── Frontend (app/) ──
+      - name: Install frontend dependencies
+        working-directory: app
+        run: npm ci
+
+      - name: TypeScript type check (app)
+        working-directory: app
+        run: npx tsc --noEmit
+
+      - name: ESLint (app)
+        working-directory: app
+        run: npx eslint .
+
+      # ── Backend ──
+      - name: Install backend dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: TypeScript type check (backend)
+        working-directory: backend
+        run: npx tsc --noEmit


### PR DESCRIPTION
## Summary
- Added GitHub Actions CI pipeline that runs on every PR to main
- TypeScript compilation errors and ESLint violations now fail the workflow

## Changes
- `.github/workflows/ci.yml`: New CI workflow with the following steps:
  - **Checkout** repository
  - **Setup Node.js 20** with npm cache
  - **Frontend (app/)**: `npm ci`, `tsc --noEmit`, `eslint .`
  - **Backend**: `npm ci`, `tsc --noEmit`

## Workflow Behavior
- Triggers on: `pull_request` to main, `push` to main
- Job name: `Lint & Type Check`
- Runner: `ubuntu-latest`
- Expected duration: < 3 minutes on clean codebase

## Required Status Check
After merging, add branch protection rule requiring `Lint & Type Check` to pass before merging to main.

## Closes
closes #20
