### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions of **AlgoForge** are currently supported with security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| main    | ✅ Yes             |
+
+## Contact Details
+
+To report a security vulnerability in **AlgoForge**, please reach out via:
+
+- 👤 Maintainer: [Rishabhworkspace](https://github.com/Rishabhworkspace)
+- 💬 Sending a private message through social links listed in the profile
+
+> Please **do not** open a public GitHub issue for security vulnerabilities.
+
+## What to Include in Your Report
+
+- A clear description of the vulnerability
+- Steps to reproduce the issue
+- Affected versions or components
+- Potential impact assessment
+- Any suggested fix (optional but appreciated)
+
+## Expected Response Time
+
+| Action                        | Timeframe         |
+| ----------------------------- | ----------------- |
+| Acknowledgement of report     | Within 48 hours   |
+| Status update                 | Within 7 days     |
+| Patch / fix release           | Within 30 days    |
+
+## Responsible Disclosure Policy
+
+We follow a **responsible disclosure** policy:
+
+- Please report vulnerabilities **privately** before any public disclosure
+- We request an **embargo period of 30 days** to investigate and patch the issue
+- After a fix is released, you are welcome to publish your findings
+- We will credit reporters in the patch notes unless anonymity is requested
+- We deeply appreciate the efforts of security researchers 🙏
+
+## References
+
+- [AlgoForge Repository](https://github.com/Rishabhworkspace/AlgoForge)
+- [GitHub Security Advisories Docs](https://docs.github.com/en/code-security/security-advisories)
+- [Responsible Disclosure — OWASP](https://owasp.org/www-community/Vulnerability_Disclosure_Cheat_Sheet)
+- [Adding a Security Policy to your repo](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)


### PR DESCRIPTION
## Description
This PR adds a `SECURITY.md` file to the repository root. AlgoForge currently has no defined security policy, leaving contributors and users with no safe, private channel to report vulnerabilities. This change establishes a responsible disclosure process following GitHub's recommended best practices.

Closes #36

## Type of Change
- [x] 📝 Documentation update
- [x] 🔒 Security

## Changes Made
- Added `SECURITY.md` at the root of the repository
- Added explicit contact details with maintainer profile link
- Included expected response timeline for reported vulnerabilities
- Outlined responsible disclosure policy with 30-day embargo period
- Added OWASP external reference link

## How Has This Been Tested?
Documentation-only change — no code was modified, no functional testing required.
- Verified `SECURITY.md` renders correctly on GitHub
- Confirmed GitHub Security tab now detects and displays the policy

## Checklist
- [x] My code follows the existing code style of the project
- [x] I have performed a self-review of my own code
- [x] I have updated the documentation if needed
- [x] My changes do not introduce any new warnings or errors
- [x] I have linked the related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security policy documentation outlining vulnerability reporting procedures, response timelines, supported versions, and responsible disclosure guidelines with embargo terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->