### PR TITLE
docs: add Contributor Covenant Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders of **AlgoForge** pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+---
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+---
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct.
+
+---
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+---
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at the repository's issue tracker or by contacting the maintainer directly via [GitHub](https://github.com/Rishabhworkspace).
+
+All complaints will be reviewed and investigated promptly and fairly. All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+---
+
+## Enforcement Guidelines
+
+Community leaders will follow these guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+**Impact:** Use of inappropriate language or other behavior deemed unprofessional.  
+**Consequence:** A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate.
+
+### 2. Warning
+**Impact:** A violation through a single incident or series of actions.  
+**Consequence:** A warning with consequences for continued behavior. No interaction with the people involved for a specified period of time.
+
+### 3. Temporary Ban
+**Impact:** A serious violation of community standards, including sustained inappropriate behavior.  
+**Consequence:** A temporary ban from any sort of interaction or public communication with the community for a specified period of time.
+
+### 4. Permanent Ban
+**Impact:** Demonstrating a pattern of violation of community standards, harassment of an individual, or aggression toward classes of individuals.  
+**Consequence:** A permanent ban from any sort of public interaction within the community.
+
+---
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).


### PR DESCRIPTION
Closes #35

## 📋 What does this PR do?
Adds a `CODE_OF_CONDUCT.md` file to the root of the repository based on the **Contributor Covenant v2.1** , the most widely adopted open-source code of conduct.

## 🤔 Why is this needed?
The project currently lacks a Code of Conduct, which is an essential community health file. Having one:
- Sets clear expectations for contributor behavior
- Makes the project more welcoming and inclusive
- Is a recommended standard for open-source projects on GitHub

## ✅ Changes Made
- Added `CODE_OF_CONDUCT.md` at the root of the repository