### PR TITLE
feat: Leaderboard privacy toggle, 60s cache, and own-rank display (closes #13)

### DIFF
--- a/app/src/sections/Dashboard.tsx
+++ b/app/src/sections/Dashboard.tsx
@@ -146,23 +146,23 @@ export function Dashboard({ onNavigate }: DashboardProps) {
 
   const { data: problemsData = [], isLoading: problemsLoading } = useQuery({
     queryKey: ['problems'],
-    queryFn: getAllProblems
+    queryFn: () => getAllProblems(),
   });
 
   const { data: topicsData = [], isLoading: topicsLoading } = useQuery({
     queryKey: ['topics'],
-    queryFn: getAllTopics
+    queryFn: () => getAllTopics(),
   });
 
   const { data: userProgressData = [], isLoading: progressLoading } = useQuery({
     queryKey: ['userProgress', profile?.id],
-    queryFn: getUserProgress,
+    queryFn: () => getUserProgress(),
     enabled: !!profile,
   });
 
   const { data: dashboardStatsData, isLoading: statsLoading } = useQuery({
     queryKey: ['dashboardStats', profile?.id],
-    queryFn: getDashboardStats,
+    queryFn: () => getDashboardStats(),
     enabled: !!profile,
   });
 

--- a/app/src/sections/Leaderboard.tsx
+++ b/app/src/sections/Leaderboard.tsx
@@ -27,10 +27,11 @@ interface LeaderboardEntry {
 }
 
 export function Leaderboard({ onProfileClick }: LeaderboardProps) {
-  const { profile } = useAuth();
+  const { profile, token } = useAuth();
   const [timeRange, setTimeRange] = useState<'all' | 'month' | 'week'>('all');
   const [category, setCategory] = useState<'xp' | 'streak' | 'solved'>('xp');
   const [leaderboardData, setLeaderboardData] = useState<LeaderboardEntry[]>([]);
+  const [myRank, setMyRank] = useState<any>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -51,6 +52,27 @@ export function Leaderboard({ onProfileClick }: LeaderboardProps) {
 
     fetchLeaderboard();
   }, [category]);
+
+  // Fetch own rank separately (always shown, even if hidden from public leaderboard)
+  useEffect(() => {
+    if (!profile) return;
+    const fetchMyRank = async () => {
+      try {
+        const token = localStorage.getItem('token');
+        if (!token) return;
+        const res = await fetch(`${API_BASE_URL}/api/users/leaderboard/me?sortBy=${category}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setMyRank(data);
+        }
+      } catch {
+        // Silently ignore — own rank is best-effort
+      }
+    };
+    fetchMyRank();
+  }, [profile, category]);
 
   const getRankIcon = (rank: number) => {
     if (rank === 1) return <Crown className="w-6 h-6 text-[#ffd700]" />;
@@ -265,8 +287,8 @@ export function Leaderboard({ onProfileClick }: LeaderboardProps) {
           ))}
         </motion.div>
 
-        {/* Current User Rank - TODO: Implement finding user rank from backend */}
-        {profile && (
+        {/* Current User Rank */}
+        {profile && myRank && (
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -275,14 +297,14 @@ export function Leaderboard({ onProfileClick }: LeaderboardProps) {
           >
             <div className="flex items-center gap-4">
               <div className="w-8 flex justify-center">
-                <span className="text-white/60 font-medium">#?</span>
+                <span className="text-[#a088ff] font-bold">#{myRank.rank}</span>
               </div>
               <div className="w-10 h-10 rounded-full bg-gradient-to-br from-[#a088ff] to-[#63e3ff] flex items-center justify-center overflow-hidden">
-                {profile.avatar?.startsWith('http') ? (
-                  <img src={profile.avatar} alt={profile.name} className="w-full h-full object-cover" />
+                {myRank.avatar?.startsWith('http') ? (
+                  <img src={myRank.avatar} alt={myRank.name} className="w-full h-full object-cover" />
                 ) : (
                   <span className="text-sm font-medium text-[#141414]">
-                    {profile.name?.charAt(0).toUpperCase() || 'Y'}
+                    {myRank.avatar || profile.name?.charAt(0).toUpperCase() || 'Y'}
                   </span>
                 )}
               </div>
@@ -293,15 +315,15 @@ export function Leaderboard({ onProfileClick }: LeaderboardProps) {
               <div className="flex items-center gap-6">
                 <div className="flex items-center gap-2 text-sm">
                   <Zap className="w-4 h-4 text-[#a088ff]" />
-                  <span className="text-white/80">{profile.xp_points || 0}</span>
+                  <span className="text-white/80">{myRank.xp.toLocaleString()}</span>
                 </div>
                 <div className="flex items-center gap-2 text-sm">
                   <Flame className="w-4 h-4 text-[#ff8a63]" />
-                  <span className="text-white/80">{profile.streak_days || 0}</span>
+                  <span className="text-white/80">{myRank.streak}</span>
                 </div>
                 <div className="flex items-center gap-2 text-sm">
                   <Target className="w-4 h-4 text-[#63e3ff]" />
-                  <span className="text-white/80">{profile.solvedProblems?.length || 0}</span>
+                  <span className="text-white/80">{myRank.solved}</span>
                 </div>
               </div>
             </div>

--- a/app/src/sections/Problems.tsx
+++ b/app/src/sections/Problems.tsx
@@ -27,19 +27,19 @@ import { SOLVE_XP } from '@/utils/xpConfig';
 export function Problems() {
   const { data: problemsData = [], isLoading: problemsLoading } = useQuery({
     queryKey: ['problems'],
-    queryFn: getAllProblems
+    queryFn: () => getAllProblems(),
   });
 
   const { data: topicsData = [], isLoading: topicsLoading } = useQuery({
     queryKey: ['topics'],
-    queryFn: getAllTopics
+    queryFn: () => getAllTopics(),
   });
 
   const { user, refreshProfile } = useAuth();
 
   const { data: userProgressData } = useQuery({
     queryKey: ['userProgress', user?.id],
-    queryFn: getUserProgress,
+    queryFn: () => getUserProgress(),
     enabled: !!user,
   });
 

--- a/app/src/sections/ProfileView.tsx
+++ b/app/src/sections/ProfileView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
-import { Zap, Flame, Target, Edit2, Check, X, ArrowLeft, User, Award } from 'lucide-react';
+import { Zap, Flame, Target, Edit2, Check, X, ArrowLeft, User, Award, EyeOff, Eye } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
@@ -15,6 +15,7 @@ interface ProfileData {
   solved: number;
   level: number;
   memberSince: string;
+  isPublic?: boolean;
 }
 
 interface ProfileViewProps {
@@ -31,6 +32,7 @@ export function ProfileView({ userId, onBack }: ProfileViewProps) {
   const [editBio, setEditBio] = useState('');
   const [editAvatarUrl, setEditAvatarUrl] = useState('');
   const [saving, setSaving] = useState(false);
+  const [isPublic, setIsPublic] = useState(true);
 
   const isOwner = user?.id === userId;
 
@@ -49,6 +51,7 @@ export function ProfileView({ userId, onBack }: ProfileViewProps) {
           setProfile(data);
           setEditBio(data.bio || '');
           setEditAvatarUrl(data.avatar || '');
+          setIsPublic(data.isPublic !== false);
         }
       } catch (error) {
         console.error('Failed to fetch profile', error);
@@ -90,6 +93,26 @@ export function ProfileView({ userId, onBack }: ProfileViewProps) {
     setEditBio(profile?.bio || '');
     setEditAvatarUrl(profile?.avatar || '');
     setIsEditing(false);
+  };
+
+  const handleTogglePrivacy = async () => {
+    if (!profile) return;
+    const newValue = !isPublic;
+    setIsPublic(newValue);
+    try {
+      const token = localStorage.getItem('token');
+      await fetch(`${API_BASE_URL}/api/users/${userId}/profile`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ isPublic: newValue }),
+      });
+    } catch {
+      // Revert on error
+      setIsPublic(!newValue);
+    }
   };
 
   if (loading) {
@@ -216,6 +239,42 @@ export function ProfileView({ userId, onBack }: ProfileViewProps) {
             </div>
           </div>
         </motion.div>
+
+        {/* Privacy Toggle (owner only) */}
+        {isOwner && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="mb-6"
+          >
+            <button
+              onClick={handleTogglePrivacy}
+              className="w-full flex items-center justify-between px-4 py-3 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 transition-colors"
+            >
+              <div className="flex items-center gap-3">
+                {isPublic ? (
+                  <Eye className="w-4 h-4 text-emerald-400" />
+                ) : (
+                  <EyeOff className="w-4 h-4 text-white/40" />
+                )}
+                <div className="text-left">
+                  <p className="text-white text-sm font-medium">Leaderboard Visibility</p>
+                  <p className="text-white/40 text-xs">
+                    {isPublic ? 'Your profile is visible on the public leaderboard' : 'Your profile is hidden from the public leaderboard'}
+                  </p>
+                </div>
+              </div>
+              <div
+                className={`relative w-10 h-6 rounded-full transition-colors ${isPublic ? 'bg-emerald-500/30' : 'bg-white/10'}`}
+              >
+                <div
+                  className={`absolute top-1 w-4 h-4 rounded-full transition-all ${isPublic ? 'left-5 bg-emerald-400' : 'left-1 bg-white/40'}`}
+                />
+              </div>
+            </button>
+          </motion.div>
+        )}
 
         {/* Stats */}
         <motion.div

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   googleId       String?         @unique
   role           String          @default("user") // "user", "admin"
   isBanned       Boolean         @default(false)
+  isPublic       Boolean         @default(true)
   avatar         String?
   avatarUrl      String?
   bio            String?         @default("")

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -2,14 +2,41 @@ import { Request, Response } from 'express';
 import { prisma } from '../config/db';
 import { calculateLevel } from '../config/xpConfig';
 
+// ─── In-memory leaderboard cache (60s TTL) ───
+const leaderboardCache = new Map<string, { data: any; expiresAt: number }>();
+const CACHE_TTL_MS = 60_000;
+
+function getCachedLeaderboard(key: string) {
+    const entry = leaderboardCache.get(key);
+    if (entry && Date.now() < entry.expiresAt) return entry.data;
+    leaderboardCache.delete(key);
+    return null;
+}
+
+function setCachedLeaderboard(key: string, data: any) {
+    leaderboardCache.set(key, { data, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
 // @desc    Get leaderboard data
 // @route   GET /api/users/leaderboard
 // @access  Public
 export const getLeaderboard = async (req: Request, res: Response) => {
     try {
         const { limit = 10, sortBy = 'xp' } = req.query;
+        const cacheKey = `lb:${sortBy}:${limit}`;
+
+        const cached = getCachedLeaderboard(cacheKey);
+        if (cached) {
+            res.setHeader('X-Cache', 'HIT');
+            return res.status(200).json(cached);
+        }
 
         let pipeline: any[] = [];
+
+        // Filter out users who opted out of the leaderboard
+        pipeline.push({
+            $match: { isPublic: { $ne: false } }
+        });
 
         pipeline.push({
             $project: {
@@ -44,8 +71,60 @@ export const getLeaderboard = async (req: Request, res: Response) => {
             rank: index + 1
         }));
 
+        setCachedLeaderboard(cacheKey, formattedLeaderboard);
+        res.setHeader('X-Cache', 'MISS');
         res.status(200).json(formattedLeaderboard);
 
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ message: 'Server Error' });
+    }
+};
+
+// @desc    Get authenticated user's own rank (always shown, even if isPublic: false)
+// @route   GET /api/users/leaderboard/me
+// @access  Private
+export const getMyLeaderboardRank = async (req: Request | any, res: Response) => {
+    try {
+        const userId = req.user.id;
+        const { sortBy = 'xp' } = req.query;
+
+        const user = await prisma.user.findUnique({ where: { id: userId } });
+        if (!user) return res.status(404).json({ message: 'User not found' });
+
+        // Count how many public users rank above this user
+        const sortField = sortBy === 'solved' ? 'solvedProblems' : sortBy === 'streak' ? 'streak_days' : 'xp_points';
+
+        let rankPipeline: any[] = [
+            { $match: { isPublic: { $ne: false } } },
+        ];
+
+        if (sortBy === 'solved') {
+            rankPipeline.push({
+                $addFields: { solvedCount: { $size: { $ifNull: ["$solvedProblems", []] } } }
+            });
+            rankPipeline.push({ $match: { solvedCount: { $gt: user.solvedProblems?.length || 0 } } });
+        } else {
+            const userVal = user[sortField as keyof typeof user] as number || 0;
+            rankPipeline.push({ $match: { [sortField]: { $gt: userVal } } });
+        }
+
+        rankPipeline.push({ $count: 'above' });
+
+        const rankResult = await prisma.user.aggregateRaw({ rankPipeline }) as unknown as any[];
+        const rank = (rankResult[0]?.above || 0) + 1;
+
+        const solvedCount = user.solvedProblems?.length || 0;
+
+        res.status(200).json({
+            id: user.id,
+            name: user.name,
+            avatar: user.avatar || (user.name ? user.name.split(' ').map((n: string) => n[0]).join('').substring(0, 2).toUpperCase() : 'U'),
+            xp: user.xp_points || 0,
+            streak: user.streak_days || 0,
+            solved: solvedCount,
+            rank,
+        });
     } catch (error) {
         console.error(error);
         res.status(500).json({ message: 'Server Error' });
@@ -162,7 +241,7 @@ export const getUserProfile = async (req: Request, res: Response) => {
 export const updateUserProfile = async (req: Request | any, res: Response) => {
     try {
         const userId = req.params.userId;
-        const { bio, avatarUrl } = req.body;
+        const { bio, avatarUrl, isPublic } = req.body;
 
         const user = await prisma.user.findUnique({ where: { id: userId } });
 
@@ -179,6 +258,7 @@ export const updateUserProfile = async (req: Request | any, res: Response) => {
             data: {
                 bio: bio !== undefined ? bio : user.bio,
                 avatarUrl: avatarUrl !== undefined ? avatarUrl : user.avatarUrl,
+                isPublic: isPublic !== undefined ? Boolean(isPublic) : user.isPublic,
             },
         });
 

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -111,7 +111,7 @@ export const getMyLeaderboardRank = async (req: Request | any, res: Response) =>
 
         rankPipeline.push({ $count: 'above' });
 
-        const rankResult = await prisma.user.aggregateRaw({ rankPipeline }) as unknown as any[];
+        const rankResult = await prisma.user.aggregateRaw({ pipeline: rankPipeline }) as unknown as any[];
         const rank = (rankResult[0]?.above || 0) + 1;
 
         const solvedCount = user.solvedProblems?.length || 0;

--- a/backend/src/routes/userRoutes.ts
+++ b/backend/src/routes/userRoutes.ts
@@ -1,10 +1,11 @@
 import express from 'express';
-import { getLeaderboard, getDashboardStats, getUserProfile, updateUserProfile } from '../controllers/userController';
+import { getLeaderboard, getMyLeaderboardRank, getDashboardStats, getUserProfile, updateUserProfile } from '../controllers/userController';
 import { protect } from '../middleware/authMiddleware';
 
 const router = express.Router();
 
 router.get('/leaderboard', getLeaderboard);
+router.get('/leaderboard/me', protect, getMyLeaderboardRank);
 router.get('/dashboard-stats', protect, getDashboardStats);
 router.get('/:userId/profile', getUserProfile);
 router.put('/:userId/profile', protect, updateUserProfile);


### PR DESCRIPTION
## Related Issue
Closes #13

## Description
Adds leaderboard privacy control and performance caching. Users can now hide themselves from the public leaderboard via a toggle in their profile. The leaderboard API response is cached for 60 seconds in-memory. Authenticated users always see their own rank below the leaderboard, even if hidden from the public list.

## Type of Change
- [x] New feature
- [x] Bug fix
- [x] UI/styling change
- [x] Documentation update
- [x] Other (describe):

## Screenshots
A "Leaderboard Visibility" toggle with eye icon appears on the user's own profile page. The leaderboard "Your Rank" card now shows the actual rank number instead of `#?`.

## Checklist
- [x] I have created/linked an issue before opening this PR
- [x] My code follows the existing code style of the project
- [x] I have tested my changes locally
- [x] No new dependencies were added (or I have explained why)
- [x] I have read the CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an owner-only “Leaderboard Visibility” privacy toggle for profile stats.
  * Added a “Current User Rank” display for signed-in visitors via a dedicated “/leaderboard/me” endpoint.
  * Improved leaderboard performance with short-term in-memory caching.
* **Bug Fixes**
  * Public leaderboards now exclude hidden profiles.
  * Replaced placeholder current-user leaderboard details with real rank, XP, streak, and solved counts.
* **Chores**
  * Added a new persistent privacy field to the user profile model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->