### PR TITLE
fix: wrap useQuery queryFn in arrow fns (TS overload) to resolve Vercel build failures

### DIFF
--- a/app/src/sections/Dashboard.tsx
+++ b/app/src/sections/Dashboard.tsx
@@ -146,23 +146,23 @@ export function Dashboard({ onNavigate }: DashboardProps) {
 
   const { data: problemsData = [], isLoading: problemsLoading } = useQuery({
     queryKey: ['problems'],
-    queryFn: getAllProblems
+    queryFn: () => getAllProblems(),
   });
 
   const { data: topicsData = [], isLoading: topicsLoading } = useQuery({
     queryKey: ['topics'],
-    queryFn: getAllTopics
+    queryFn: () => getAllTopics(),
   });
 
   const { data: userProgressData = [], isLoading: progressLoading } = useQuery({
     queryKey: ['userProgress', profile?.id],
-    queryFn: getUserProgress,
+    queryFn: () => getUserProgress(),
     enabled: !!profile,
   });
 
   const { data: dashboardStatsData, isLoading: statsLoading } = useQuery({
     queryKey: ['dashboardStats', profile?.id],
-    queryFn: getDashboardStats,
+    queryFn: () => getDashboardStats(),
     enabled: !!profile,
   });
 

--- a/app/src/sections/Problems.tsx
+++ b/app/src/sections/Problems.tsx
@@ -27,19 +27,19 @@ import { SOLVE_XP } from '@/utils/xpConfig';
 export function Problems() {
   const { data: problemsData = [], isLoading: problemsLoading } = useQuery({
     queryKey: ['problems'],
-    queryFn: getAllProblems
+    queryFn: () => getAllProblems(),
   });
 
   const { data: topicsData = [], isLoading: topicsLoading } = useQuery({
     queryKey: ['topics'],
-    queryFn: getAllTopics
+    queryFn: () => getAllTopics(),
   });
 
   const { user, refreshProfile } = useAuth();
 
   const { data: userProgressData } = useQuery({
     queryKey: ['userProgress', user?.id],
-    queryFn: getUserProgress,
+    queryFn: () => getUserProgress(),
     enabled: !!user,
   });
 


### PR DESCRIPTION
## Summary
Wraps useQuery > queryFn callback as arrow-functions to pass TypeScript type-checking.

## Root Cause
getAllProblems, getAllTopics, getUserProgress, getDashboardStats all accept optional parameters; when passed directly as queryFn, TS interprets the function as having the QueryFunctionContext callback signature — causing TS overload-mismatch error (TS2769) — which cascades into data receiving type unknown — breaking all downstream .map(), .filter(), .length() calls.

## Changes
- **src/sections/Dashboard.tsx**: wrap 4 useQuery instances: queryFn: () => apiFunc() (ts overload mitigated)
- **src/sections/Problems.tsx**: wrap 3 useQuery instances: same arrow-wrapper pattern

## Verification
- 	sc -b --noEmit — clean (0 errors)
- 
pm run build — ✓ built in 10.17s

## Closes AlgoForge Vercel build failures
| PR | Branch | Build |
|---|---|---|
| #62 #63 #64 #65 #66 #67 | all | Previously failed (TS18046/2769 P)V — now builds

This PR unblocks Vercel deploys for all AlgoForge PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data loading reliability across dashboard and problem views.
  * Ensured related content, topics, and progress information are fetched correctly without changing the existing loading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->